### PR TITLE
Randomly initialize new users to a game group

### DIFF
--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -2,7 +2,7 @@ import * as firebase from "firebase/app";
 import { createUserWithEmailAndPassword, getAuth, sendEmailVerification, sendPasswordResetEmail, signInWithEmailAndPassword, EmailAuthProvider, reauthenticateWithCredential, updatePassword, signOut } from "firebase/auth";
 import { doc, getDoc, getFirestore, setDoc, Timestamp, collection, getDocs } from "firebase/firestore";
 import { User, Word } from "../models/types";
-import { getRandomPairing, getTestDate, shuffle } from "../utils/utils";
+import { getRandomPairing, getTestDate, shuffle, getRandomGameType } from "../utils/utils";
 
 
 // Your web app's Firebase configuration
@@ -51,6 +51,7 @@ export default class FirebaseInteractor {
         const userDoc = doc(this.db, "users", userAuth.user.uid)
         await setDoc(userDoc, {
             numPairs: getRandomPairing(),
+            gameType: getRandomGameType(),
             testDate: Timestamp.fromDate(getTestDate()),
             sessions: [],
             seenPairs: []

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -1,5 +1,5 @@
 export type NumPairs = 2 | 4 | 8;
-export type GameType = "matching" | "multipleChoice";
+export type GameType = "pairing" | "selecting";
 export interface User {
     email: string;
     testDate: Date;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { NumPairs } from "../models/types";
+import { NumPairs, GameType } from "../models/types";
 
 export function getRandomPairing(): NumPairs {
     let choice = Math.floor(Math.random() * 3);
@@ -43,7 +43,7 @@ export function mapErrorCodeToMessage(code: string) {
 /**
  * Produces a random game type.
  */
-export function getRandomGameType(): String {
-    const gameTypes = ["pairing", "selecting"];
+export function getRandomGameType(): GameType {
+    const gameTypes: GameType[] = ["pairing", "selecting"];
     return gameTypes[Math.floor(Math.random() * gameTypes.length)];
 }

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -39,3 +39,11 @@ export function mapErrorCodeToMessage(code: string) {
             return "Unknown error: " + code;
     }
 }
+
+/**
+ * Produces a random game type.
+ */
+export function getRandomGameType(): String {
+    const gameTypes = ["pairing", "selecting"];
+    return gameTypes[Math.floor(Math.random() * gameTypes.length)];
+}


### PR DESCRIPTION
- Defined two game type strings: `pairing` and `selecting`
- Added functionality to randomly select a game type
- Added `gameType` field to `user` Firestore document