### PR TITLE
reset error and success message on account settings

### DIFF
--- a/frontend/src/screens/Login/accountSettings.tsx
+++ b/frontend/src/screens/Login/accountSettings.tsx
@@ -25,6 +25,8 @@ export default function AccountSettings() {
         <ErrorText message={error} />
         <Text>{successMessage}</Text>
         <TouchableOpacity onPress={() => {
+            setError("");
+            setSuccesMessage("");
             if (!currentPassword) {
                 setError("Please enter your current password.");
             } else if (!newPassword) {

--- a/frontend/src/screens/Login/accountSettings.tsx
+++ b/frontend/src/screens/Login/accountSettings.tsx
@@ -13,7 +13,7 @@ export default function AccountSettings() {
     const [currentPassword, setCurrentPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
     const [error, setError] = useState("");
-    const [successMessage, setSuccesMessage] = useState("")
+    const [successMessage, setSuccessMessage] = useState("")
 
     const navigation = useNavigation();
 
@@ -26,7 +26,7 @@ export default function AccountSettings() {
         <Text>{successMessage}</Text>
         <TouchableOpacity onPress={() => {
             setError("");
-            setSuccesMessage("");
+            setSuccessMessage("");
             if (!currentPassword) {
                 setError("Please enter your current password.");
             } else if (!newPassword) {
@@ -35,7 +35,7 @@ export default function AccountSettings() {
                 setError("New password cannot be the same as the old passowrd.")
             } else {
                 fi.updatePassword(currentPassword, newPassword).then(() => {
-                    setSuccesMessage("Successfully changed password.")
+                    setSuccessMessage("Successfully changed password.")
                 }).catch(e => setError(mapErrorCodeToMessage(e.code)))
             }
         }}>


### PR DESCRIPTION
Closes: #39
Originally could get into a state where a success and error message was visible. Made this impossible by resetting messages before every request.