### PR TITLE
60 drag and drop

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
+    "react-native-drax": "^0.9.1",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^2.2.4",
     "react-native-safe-area-context": "3.2.0",

--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -1,5 +1,4 @@
-import { TouchableOpacity } from "react-native-gesture-handler";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View, TouchableOpacity } from "react-native";
 import React from "react";
 import { DraxView } from "react-native-drax";
 interface DroppableRowProps {
@@ -7,25 +6,62 @@ interface DroppableRowProps {
     english?: string,
     removeWord: () => void;
     wordDropped: (word: string) => void;
+    // submitted: boolean;
+    // correctEnglishWord: string
 }
 
 export default function DroppableRow({ turkish, english, removeWord, wordDropped }: DroppableRowProps) {
     return (<View style={styles.container}>
-        {english ? <TouchableOpacity onPress={removeWord}><Text>{english}</Text></TouchableOpacity> : <DraxView style={styles.draxView}
-            onReceiveDragDrop={({ dragged: { payload } }: { dragged: { payload: string } }) => {
-                wordDropped(payload);
-            }}></DraxView>}
-        <Text>{turkish}</Text>
+        {english ?
+            <TouchableOpacity style={styles.englishTextContainer} onPress={removeWord}>
+                <Text style={styles.englishText}>{english}</Text>
+            </TouchableOpacity>
+            : <DraxView style={styles.draxView}
+                onReceiveDragDrop={({ dragged: { payload } }: { dragged: { payload: string } }) => {
+                    wordDropped(payload);
+                }}></DraxView>}
+        <Text style={styles.turkishText}>{turkish}</Text>
     </View>)
 }
 
 const styles = StyleSheet.create({
     draxView: {
+        borderColor: "#5BBAB7",
+        borderWidth: 3,
         width: "40%",
-        borderColor: "green",
-        borderWidth: 5
+        borderStyle: "dashed",
+        height: "100%",
+        marginHorizontal: "5%",
+        borderRadius: 0.0001
+    },
+    turkishText: {
+        width: "40%",
+        textAlign: "center",
+        backgroundColor: "#C4C4C4",
+        paddingVertical: "2%",
+        color: "white"
+    },
+    englishTextContainer: {
+        width: "40%",
+        textAlign: "center",
+        borderColor: "white",
+        borderStyle: "dashed",
+        borderWidth: 4,
+        backgroundColor: "#5EAFDF",
+        paddingVertical: "2%",
+        color: "white",
+        marginHorizontal: "5%",
+        borderRadius: 0.000001
+    },
+    englishText: {
+        color: 'white',
+        textAlign: 'center'
     },
     container: {
-        flexDirection: "row"
+        flexDirection: "row",
+        alignItems: 'center',
+        width: "100%",
+        height: 30,
+        marginVertical: "1%"
     }
 });

--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -23,7 +23,9 @@ export default function DroppableRow({ turkish, english, removeWord, wordDropped
                 onReceiveDragDrop={({ dragged: { payload } }: { dragged: { payload: string } }) => {
                     wordDropped(payload);
                 }}></DraxView>}
-        <Text style={{ ...styles.turkishText, ...extraTurkishInfo }}>{turkish}</Text>
+        <View style={styles.turkishContainer}>
+            <Text style={{... styles.turkishText, ...extraTurkishInfo}}>{turkish}</Text>
+        </View>
     </View>)
 }
 
@@ -54,13 +56,16 @@ const styles = StyleSheet.create({
         marginHorizontal: "5%",
         borderRadius: 0.0001
     },
-    turkishText: {
+    turkishContainer: {
+        justifyContent: "center",
         width: "40%",
-        textAlign: "center",
+        height: "100%",
         backgroundColor: "#C4C4C4",
-        paddingVertical: "2%",
-        color: "white",
         marginHorizontal: "5%"
+    },
+    turkishText: {
+        textAlign: "center",
+        color: "white",
     },
     englishTextContainer: {
         width: "40%",
@@ -69,9 +74,10 @@ const styles = StyleSheet.create({
         borderStyle: "dashed",
         borderWidth: 4,
         backgroundColor: "#5EAFDF",
-        paddingVertical: "2%",
+        height: "100%",
         color: "white",
         marginHorizontal: "5%",
+        justifyContent: "center",
         borderRadius: 0.000001
     },
     englishText: {
@@ -82,7 +88,7 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: 'center',
         width: "100%",
-        height: "11.5%",
-        marginVertical: "0.5%",
+        flex: 1,
+        marginVertical: "1%"
     }
 });

--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -6,23 +6,34 @@ interface DroppableRowProps {
     english?: string,
     removeWord: () => void;
     wordDropped: (word: string) => void;
-    // submitted: boolean;
-    // correctEnglishWord: string
+    showingResults: boolean
 }
 
-export default function DroppableRow({ turkish, english, removeWord, wordDropped }: DroppableRowProps) {
+export default function DroppableRow({ turkish, english, removeWord, wordDropped, showingResults }: DroppableRowProps) {
+    const extraEnglishInfo = showingResults ? showingResultsStyles.englishWord : {}
+    const extraTurkishInfo = showingResults ? showingResultsStyles.turkishWord : {}
     return (<View style={styles.container}>
         {english ?
-            <TouchableOpacity style={styles.englishTextContainer} onPress={removeWord}>
+            <TouchableOpacity style={{...styles.englishTextContainer, ...extraEnglishInfo}} onPress={() => !showingResults && removeWord()} disabled={showingResults}>
                 <Text style={styles.englishText}>{english}</Text>
             </TouchableOpacity>
             : <DraxView style={styles.draxView}
                 onReceiveDragDrop={({ dragged: { payload } }: { dragged: { payload: string } }) => {
                     wordDropped(payload);
                 }}></DraxView>}
-        <Text style={styles.turkishText}>{turkish}</Text>
+        <Text style={{... styles.turkishText, ...extraTurkishInfo}}>{turkish}</Text>
     </View>)
 }
+
+const showingResultsStyles = StyleSheet.create({
+    englishWord: {
+        backgroundColor: "#5BBAB780",
+        borderColor: "transparent"
+    },
+    turkishWord: {
+        backgroundColor: "#C4C4C480"
+    }
+})
 
 const styles = StyleSheet.create({
     draxView: {
@@ -55,13 +66,13 @@ const styles = StyleSheet.create({
     },
     englishText: {
         color: 'white',
-        textAlign: 'center'
+        textAlign: 'center',
     },
     container: {
         flexDirection: "row",
         alignItems: 'center',
         width: "100%",
-        height: 30,
+        height: 50,
         marginVertical: "1%"
     }
 });

--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -4,34 +4,43 @@ import { DraxView } from "react-native-drax";
 interface DroppableRowProps {
     turkish: string,
     english?: string,
+    correctEnglish: string,
     removeWord: () => void;
     wordDropped: (word: string) => void;
     showingResults: boolean
 }
 
-export default function DroppableRow({ turkish, english, removeWord, wordDropped, showingResults }: DroppableRowProps) {
-    const extraEnglishInfo = showingResults ? showingResultsStyles.englishWord : {}
-    const extraTurkishInfo = showingResults ? showingResultsStyles.turkishWord : {}
+export default function DroppableRow({ turkish, english, removeWord, wordDropped, showingResults, correctEnglish }: DroppableRowProps) {
+    const correct = english === correctEnglish;
+    const extraEnglishInfo = showingResults ? correct ? showingResultsStyles.correctEnglishWord : showingResultsStyles.incorrectEnglishWord : {}
+    const extraTurkishInfo = showingResults ? correct ? showingResultsStyles.correctTurkishWord : showingResultsStyles.incorrectTurkishWord : {}
     return (<View style={styles.container}>
         {english ?
-            <TouchableOpacity style={{...styles.englishTextContainer, ...extraEnglishInfo}} onPress={() => !showingResults && removeWord()} disabled={showingResults}>
+            <TouchableOpacity style={{ ...styles.englishTextContainer, ...extraEnglishInfo }} onPress={() => !showingResults && removeWord()} disabled={showingResults}>
                 <Text style={styles.englishText}>{english}</Text>
             </TouchableOpacity>
             : <DraxView style={styles.draxView}
                 onReceiveDragDrop={({ dragged: { payload } }: { dragged: { payload: string } }) => {
                     wordDropped(payload);
                 }}></DraxView>}
-        <Text style={{... styles.turkishText, ...extraTurkishInfo}}>{turkish}</Text>
+        <Text style={{ ...styles.turkishText, ...extraTurkishInfo }}>{turkish}</Text>
     </View>)
 }
 
 const showingResultsStyles = StyleSheet.create({
-    englishWord: {
+    incorrectEnglishWord: {
         backgroundColor: "#5BBAB780",
         borderColor: "transparent"
     },
-    turkishWord: {
+    incorrectTurkishWord: {
         backgroundColor: "#C4C4C480"
+    },
+    correctEnglishWord: {
+        backgroundColor: "#5BBAB7",
+        borderColor: "transparent"
+    },
+    correctTurkishWord: {
+        backgroundColor: "#C4C4C4"
     }
 })
 
@@ -50,7 +59,8 @@ const styles = StyleSheet.create({
         textAlign: "center",
         backgroundColor: "#C4C4C4",
         paddingVertical: "2%",
-        color: "white"
+        color: "white",
+        marginHorizontal: "5%"
     },
     englishTextContainer: {
         width: "40%",
@@ -72,7 +82,7 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: 'center',
         width: "100%",
-        height: 50,
-        marginVertical: "1%"
+        height: "11.5%",
+        marginVertical: "0.5%",
     }
 });

--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
         textAlign: "center",
         borderColor: "white",
         borderStyle: "dashed",
-        borderWidth: 4,
+        borderWidth: 2,
         backgroundColor: "#5EAFDF",
         height: "100%",
         color: "white",

--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -1,0 +1,31 @@
+import { TouchableOpacity } from "react-native-gesture-handler";
+import { StyleSheet, Text, View } from "react-native";
+import React from "react";
+import { DraxView } from "react-native-drax";
+interface DroppableRowProps {
+    turkish: string,
+    english?: string,
+    removeWord: () => void;
+    wordDropped: (word: string) => void;
+}
+
+export default function DroppableRow({ turkish, english, removeWord, wordDropped }: DroppableRowProps) {
+    return (<View style={styles.container}>
+        {english ? <TouchableOpacity onPress={removeWord}><Text>{english}</Text></TouchableOpacity> : <DraxView style={styles.draxView}
+            onReceiveDragDrop={({ dragged: { payload } }: { dragged: { payload: string } }) => {
+                wordDropped(payload);
+            }}></DraxView>}
+        <Text>{turkish}</Text>
+    </View>)
+}
+
+const styles = StyleSheet.create({
+    draxView: {
+        width: "40%",
+        borderColor: "green",
+        borderWidth: 5
+    },
+    container: {
+        flexDirection: "row"
+    }
+});

--- a/frontend/src/screens/pairingGameScreen.tsx
+++ b/frontend/src/screens/pairingGameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { BLUE, GREY } from "../constants/colors";
 import FirebaseInteractor from "../firebase/firebaseInteractor";
 import { User, Word } from "../models/types";
@@ -11,35 +11,39 @@ const fi = new FirebaseInteractor();
 interface MaybeWordPair {
     english?: string;
     turkish: string;
+    correctEnglishWord: string;
 }
 
 export default function PairingGameScreen() {
     const [englishWords, setEnglishWords] = useState<string[]>()
     const [turkishWords, setTurkishWords] = useState<MaybeWordPair[]>()
     const [user, setUser] = useState<User>();
+    const [submitted, setSubmitted] = useState(false);
 
     useEffect(() => {
         fi.getUser().then(user => {
             setUser(user);
             fi.getXRandomPairs(user.numPairs).then(words => {
                 setEnglishWords(durstenfeldShuffle(words.map((word, i) => word.english)));
-                setTurkishWords(durstenfeldShuffle(words.map((word, i) => ({ turkish: word.turkish }))));
+                setTurkishWords(durstenfeldShuffle(words.map((word, i) => ({ turkish: word.turkish, correctEnglishWord: word.english }))));
             }).catch(console.error);
         }).catch(console.error);
     }, []);
 
-    if (englishWords?.length === 0) {
+    if (englishWords === undefined) {
         return <Text>loading</Text>
     }
 
+    const correctValues = turkishWords?.filter(({ english, correctEnglishWord }) => english === correctEnglishWord).length ?? 0;
     return (
         <DraxProvider>
             <View style={styles.container}>
                 <View style={styles.column}>
-                    {englishWords?.map(word =>
-                        <DraxView payload={word} key={word} style={styles.draxView}>
-                            <Text style={styles.english}>{word}</Text>
-                        </DraxView>)}
+                    {submitted ? <Text style={styles.scoreText}>{correctValues}/{turkishWords?.length ?? 0}</Text> :
+                        englishWords?.map(word =>
+                            <DraxView payload={word} key={word} style={styles.draxView}>
+                                <Text style={styles.english}>{word}</Text>
+                            </DraxView>)}
                 </View>
                 <View style={styles.turkishContainer}>
                     {turkishWords?.map((word, i) => (
@@ -47,7 +51,7 @@ export default function PairingGameScreen() {
                             key={word.turkish}
                             wordDropped={(newWord) => {
                                 const newTurkishWords = turkishWords
-                                newTurkishWords[i] = { english: newWord, turkish: word.turkish }
+                                newTurkishWords[i] = { english: newWord, turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
                                 setTurkishWords(newTurkishWords)
                                 setEnglishWords(englishWords?.filter((word) => word !== newWord))
                             }}
@@ -56,7 +60,7 @@ export default function PairingGameScreen() {
                             removeWord={
                                 () => {
                                     const newTurkishWords = [...turkishWords]
-                                    newTurkishWords[i] = { turkish: word.turkish }
+                                    newTurkishWords[i] = { turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
                                     const newEnglishWords = [...englishWords!]
                                     newEnglishWords?.push(word.english!)
                                     console.log(newEnglishWords)
@@ -66,6 +70,7 @@ export default function PairingGameScreen() {
                         />))}
                 </View>
             </View>
+            <TouchableOpacity style={styles.doneButton} onPress={() => setSubmitted(true)}><Text style={styles.doneButtonTitle}>done</Text></TouchableOpacity>
         </DraxProvider>
     )
 }
@@ -83,36 +88,51 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: "center",
         width: "100%",
-        height: "100%"
+        height: "100%",
     },
     column: {
         flex: 1,
         width: "100%",
         alignItems: "center",
         paddingTop: "10%",
-        height: "50%",
         flexWrap: "wrap",
         flexDirection: "row"
 
     },
     turkishContainer: {
-
+        width: "100%",
+        flex: 1
     },
     english: {
         ...defaultStyle.default,
-        paddingVertical: "7%",
+        paddingVertical: "10%",
+        marginVertical: "4%",
         backgroundColor: BLUE
-    },
-    turkish: {
-        ...defaultStyle.default,
-        backgroundColor: GREY
     },
     draxView: {
         width: "40%",
         marginHorizontal: "5%",
-        height: "15%"
+        height: "15%",
+        marginVertical: "3%"
     },
-    turkishDraxView: {
+    doneButton: {
+        backgroundColor: "#D16B50",
+        borderRadius: 12,
+        height: "5%",
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: "20%",
+        marginBottom: "2%",
+        marginLeft: "40%"
+    },
+    doneButtonTitle: {
+        color: "white"
+    },
+    scoreText: {
+        color: BLUE,
+        fontSize: 124,
+        textAlign: "center",
+        width: "100%"
     }
 })
 

--- a/frontend/src/screens/pairingGameScreen.tsx
+++ b/frontend/src/screens/pairingGameScreen.tsx
@@ -37,20 +37,21 @@ export default function PairingGameScreen() {
     }
 
     const correctValues = turkishWords?.filter(({ english, correctEnglishWord }) => english === correctEnglishWord).length ?? 0;
-    const canClickDoneButton = englishWords.every((word) => turkishWords?.some(({english}) => english === word))
+    const canClickDoneButton = englishWords.every((word) => turkishWords?.some(({ english }) => english === word))
     const extraButtonStyles = canClickDoneButton ? {} : styles.inactiveButton
     return (
         <DraxProvider>
             <View style={styles.column}>
                 {submitted ? <Text style={styles.scoreText}>{correctValues}/{turkishWords?.length ?? 0}</Text> :
                     englishWords?.map(word => {
-                        if (turkishWords?.some(({english}) => english === word) ?? false) {
-                            return (<View key={word} style={styles.englishUsed}/>)
+                        if (turkishWords?.some(({ english }) => english === word) ?? false) {
+                            return (<View key={word} style={styles.englishUsed} />)
                         }
-                        return (<DraxView payload={word} key={word} style={styles.draxView}>
+                        return (<DraxView payload={word} key={word} style={styles.draxView} draggingStyle={styles.englishUsed} dragReleasedStyle={styles.englishUsed}>
                             <Text style={styles.english}>{word}</Text>
-                        </DraxView>)})
-                    }   
+                        </DraxView>)
+                    })
+                }
             </View>
             <View style={styles.turkishContainer}>
                 {turkishWords?.map((word, i) => (
@@ -64,6 +65,7 @@ export default function PairingGameScreen() {
                         }}
                         turkish={word.turkish}
                         english={word.english}
+                        correctEnglish={word.correctEnglishWord}
                         removeWord={
                             () => {
                                 const newTurkishWords = [...turkishWords]
@@ -74,16 +76,16 @@ export default function PairingGameScreen() {
             </View>
             <View style={styles.doneContainer}>
                 {submitted && <TouchableOpacity style={styles.doneButton} onPress={() => {
-                    setTurkishWords(turkishWords?.map((word) => ({...word, english: undefined})))
+                    setTurkishWords(turkishWords?.map((word) => ({ ...word, english: undefined })))
                     setSubmitted(false)
-                    }}><Text style={styles.doneButtonTitle}>play again</Text></TouchableOpacity>}
-                <TouchableOpacity style={{...styles.doneButton, ...extraButtonStyles}} disabled={!canClickDoneButton} onPress={() => {
+                }}><Text style={styles.doneButtonTitle}>play again</Text></TouchableOpacity>}
+                <TouchableOpacity style={{ ...styles.doneButton, ...extraButtonStyles }} disabled={!canClickDoneButton} onPress={() => {
                     if (submitted) {
                         navigation.navigate("home")
                     } else {
                         setSubmitted(true)
                     }
-                    }}><Text style={styles.doneButtonTitle}>{submitted ? "end session" : "done"}</Text></TouchableOpacity>
+                }}><Text style={styles.doneButtonTitle}>{submitted ? "end session" : "done"}</Text></TouchableOpacity>
             </View>
         </DraxProvider>
     )
@@ -108,22 +110,22 @@ const styles = StyleSheet.create({
         backgroundColor: "#D16B5025",
     },
     column: {
-        flex: 10,
+        flex: 8,
         width: "100%",
         alignItems: "center",
         paddingTop: "10%",
         flexWrap: "wrap",
-        flexDirection: "row"
+        flexDirection: "row",
     },
     turkishContainer: {
         width: "100%",
-        flex: 10
+        flex: 10,
     },
     english: {
         ...defaultStyle.default,
         paddingVertical: "10%",
         marginVertical: "4%",
-        backgroundColor: BLUE
+        backgroundColor: BLUE,
     },
     draxView: {
         width: "40%",
@@ -141,7 +143,7 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         alignItems: 'center',
         paddingHorizontal: "10%",
-        marginBottom: "2%",
+        marginVertical: "1%",
         paddingVertical: 10
     },
     doneButtonTitle: {

--- a/frontend/src/screens/pairingGameScreen.tsx
+++ b/frontend/src/screens/pairingGameScreen.tsx
@@ -4,12 +4,18 @@ import { BLUE, GREY } from "../constants/colors";
 import FirebaseInteractor from "../firebase/firebaseInteractor";
 import { User, Word } from "../models/types";
 import { durstenfeldShuffle } from "../utils/utils";
-
+import { DraxView, DraxProvider } from "react-native-drax";
+import DroppableRow from "../components/DroppableRow";
 const fi = new FirebaseInteractor();
+
+interface MaybeWordPair {
+    english?: string;
+    turkish: string;
+}
 
 export default function PairingGameScreen() {
     const [englishWords, setEnglishWords] = useState<string[]>()
-    const [turkishWords, setTurkishWords] = useState<string[]>()
+    const [turkishWords, setTurkishWords] = useState<MaybeWordPair[]>()
     const [user, setUser] = useState<User>();
 
     useEffect(() => {
@@ -17,7 +23,7 @@ export default function PairingGameScreen() {
             setUser(user);
             fi.getXRandomPairs(user.numPairs).then(words => {
                 setEnglishWords(durstenfeldShuffle(words.map((word, i) => word.english)));
-                setTurkishWords(durstenfeldShuffle(words.map((word, i) => word.turkish)));
+                setTurkishWords(durstenfeldShuffle(words.map((word, i) => ({ turkish: word.turkish }))));
             }).catch(console.error);
         }).catch(console.error);
     }, []);
@@ -26,45 +32,87 @@ export default function PairingGameScreen() {
         return <Text>loading</Text>
     }
 
-    return (<View style={styles.container}>
-        <View style={styles.column}>
-            {englishWords?.map(word => <Text style={styles.english}>{word}</Text>)}
-        </View>
-        <View style={styles.column}>
-            {turkishWords?.map(word => <Text style={styles.turkish}>{word}</Text>)}
-        </View>
-    </View>)
+    return (
+        <DraxProvider>
+            <View style={styles.container}>
+                <View style={styles.column}>
+                    {englishWords?.map(word =>
+                        <DraxView payload={word} key={word} style={styles.draxView}>
+                            <Text style={styles.english}>{word}</Text>
+                        </DraxView>)}
+                </View>
+                <View style={styles.turkishContainer}>
+                    {turkishWords?.map((word, i) => (
+                        <DroppableRow
+                            key={word.turkish}
+                            wordDropped={(newWord) => {
+                                const newTurkishWords = turkishWords
+                                newTurkishWords[i] = { english: newWord, turkish: word.turkish }
+                                setTurkishWords(newTurkishWords)
+                                setEnglishWords(englishWords?.filter((word) => word !== newWord))
+                            }}
+                            turkish={word.turkish}
+                            english={word.english}
+                            removeWord={
+                                () => {
+                                    const newTurkishWords = [...turkishWords]
+                                    newTurkishWords[i] = { turkish: word.turkish }
+                                    const newEnglishWords = [...englishWords!]
+                                    newEnglishWords?.push(word.english!)
+                                    console.log(newEnglishWords)
+                                    setTurkishWords(newTurkishWords)
+                                    setEnglishWords(newEnglishWords)
+                                }}
+                        />))}
+                </View>
+            </View>
+        </DraxProvider>
+    )
 }
 
 const defaultStyle = StyleSheet.create({
     default: {
         color: "white",
-        width: "80%",
-        marginVertical: 5,
         borderRadius: 5,
         textAlign: "center",
-        paddingVertical: "4%"
     }
 });
 
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        flexDirection: "row"
+        alignItems: "center",
+        width: "100%",
+        height: "100%"
     },
     column: {
         flex: 1,
-        width: "50%",
+        width: "100%",
         alignItems: "center",
-        paddingTop: "10%"
+        paddingTop: "10%",
+        height: "50%",
+        flexWrap: "wrap",
+        flexDirection: "row"
+
+    },
+    turkishContainer: {
+
     },
     english: {
         ...defaultStyle.default,
+        paddingVertical: "7%",
         backgroundColor: BLUE
     },
     turkish: {
         ...defaultStyle.default,
         backgroundColor: GREY
+    },
+    draxView: {
+        width: "40%",
+        marginHorizontal: "5%",
+        height: "15%"
+    },
+    turkishDraxView: {
     }
 })
 

--- a/frontend/src/screens/pairingGameScreen.tsx
+++ b/frontend/src/screens/pairingGameScreen.tsx
@@ -6,6 +6,7 @@ import { User, Word } from "../models/types";
 import { durstenfeldShuffle } from "../utils/utils";
 import { DraxView, DraxProvider } from "react-native-drax";
 import DroppableRow from "../components/DroppableRow";
+import { useNavigation } from "@react-navigation/core";
 const fi = new FirebaseInteractor();
 
 interface MaybeWordPair {
@@ -19,6 +20,7 @@ export default function PairingGameScreen() {
     const [turkishWords, setTurkishWords] = useState<MaybeWordPair[]>()
     const [user, setUser] = useState<User>();
     const [submitted, setSubmitted] = useState(false);
+    const navigation = useNavigation()
 
     useEffect(() => {
         fi.getUser().then(user => {
@@ -35,42 +37,54 @@ export default function PairingGameScreen() {
     }
 
     const correctValues = turkishWords?.filter(({ english, correctEnglishWord }) => english === correctEnglishWord).length ?? 0;
+    const canClickDoneButton = englishWords.every((word) => turkishWords?.some(({english}) => english === word))
+    const extraButtonStyles = canClickDoneButton ? {} : styles.inactiveButton
     return (
         <DraxProvider>
-            <View style={styles.container}>
-                <View style={styles.column}>
-                    {submitted ? <Text style={styles.scoreText}>{correctValues}/{turkishWords?.length ?? 0}</Text> :
-                        englishWords?.map(word =>
-                            <DraxView payload={word} key={word} style={styles.draxView}>
-                                <Text style={styles.english}>{word}</Text>
-                            </DraxView>)}
-                </View>
-                <View style={styles.turkishContainer}>
-                    {turkishWords?.map((word, i) => (
-                        <DroppableRow
-                            key={word.turkish}
-                            wordDropped={(newWord) => {
-                                const newTurkishWords = turkishWords
-                                newTurkishWords[i] = { english: newWord, turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
-                                setTurkishWords(newTurkishWords)
-                                setEnglishWords(englishWords?.filter((word) => word !== newWord))
-                            }}
-                            turkish={word.turkish}
-                            english={word.english}
-                            removeWord={
-                                () => {
-                                    const newTurkishWords = [...turkishWords]
-                                    newTurkishWords[i] = { turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
-                                    const newEnglishWords = [...englishWords!]
-                                    newEnglishWords?.push(word.english!)
-                                    console.log(newEnglishWords)
-                                    setTurkishWords(newTurkishWords)
-                                    setEnglishWords(newEnglishWords)
-                                }}
-                        />))}
-                </View>
+            <View style={styles.column}>
+                {submitted ? <Text style={styles.scoreText}>{correctValues}/{turkishWords?.length ?? 0}</Text> :
+                    englishWords?.map(word => {
+                        if (turkishWords?.some(({english}) => english === word) ?? false) {
+                            return (<View key={word} style={styles.englishUsed}/>)
+                        }
+                        return (<DraxView payload={word} key={word} style={styles.draxView}>
+                            <Text style={styles.english}>{word}</Text>
+                        </DraxView>)})
+                    }   
             </View>
-            <TouchableOpacity style={styles.doneButton} onPress={() => setSubmitted(true)}><Text style={styles.doneButtonTitle}>done</Text></TouchableOpacity>
+            <View style={styles.turkishContainer}>
+                {turkishWords?.map((word, i) => (
+                    <DroppableRow
+                        key={word.turkish}
+                        showingResults={submitted}
+                        wordDropped={(newWord) => {
+                            const newTurkishWords = [...turkishWords]
+                            newTurkishWords[i] = { english: newWord, turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
+                            setTurkishWords(newTurkishWords)
+                        }}
+                        turkish={word.turkish}
+                        english={word.english}
+                        removeWord={
+                            () => {
+                                const newTurkishWords = [...turkishWords]
+                                newTurkishWords[i] = { turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
+                                setTurkishWords(newTurkishWords)
+                            }}
+                    />))}
+            </View>
+            <View style={styles.doneContainer}>
+                {submitted && <TouchableOpacity style={styles.doneButton} onPress={() => {
+                    setTurkishWords(turkishWords?.map((word) => ({...word, english: undefined})))
+                    setSubmitted(false)
+                    }}><Text style={styles.doneButtonTitle}>play again</Text></TouchableOpacity>}
+                <TouchableOpacity style={{...styles.doneButton, ...extraButtonStyles}} disabled={!canClickDoneButton} onPress={() => {
+                    if (submitted) {
+                        navigation.navigate("home")
+                    } else {
+                        setSubmitted(true)
+                    }
+                    }}><Text style={styles.doneButtonTitle}>{submitted ? "end session" : "done"}</Text></TouchableOpacity>
+            </View>
         </DraxProvider>
     )
 }
@@ -88,20 +102,22 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: "center",
         width: "100%",
-        height: "100%",
+        height: "100%"
+    },
+    inactiveButton: {
+        backgroundColor: "#D16B5025",
     },
     column: {
-        flex: 1,
+        flex: 10,
         width: "100%",
         alignItems: "center",
         paddingTop: "10%",
         flexWrap: "wrap",
         flexDirection: "row"
-
     },
     turkishContainer: {
         width: "100%",
-        flex: 1
+        flex: 10
     },
     english: {
         ...defaultStyle.default,
@@ -115,15 +131,18 @@ const styles = StyleSheet.create({
         height: "15%",
         marginVertical: "3%"
     },
+    doneContainer: {
+        flex: 3,
+        alignItems: "center",
+    },
     doneButton: {
         backgroundColor: "#D16B50",
         borderRadius: 12,
-        height: "5%",
         justifyContent: 'center',
         alignItems: 'center',
-        width: "20%",
+        paddingHorizontal: "10%",
         marginBottom: "2%",
-        marginLeft: "40%"
+        paddingVertical: 10
     },
     doneButtonTitle: {
         color: "white"
@@ -133,6 +152,16 @@ const styles = StyleSheet.create({
         fontSize: 124,
         textAlign: "center",
         width: "100%"
+    },
+    englishUsed: {
+        borderColor: BLUE,
+        borderWidth: 1,
+        width: "40%",
+        borderStyle: "dashed",
+        height: "15%",
+        marginVertical: "3%",
+        marginHorizontal: "5%",
+        borderRadius: 0.0001
     }
 })
 

--- a/frontend/src/screens/pairingGameScreen.tsx
+++ b/frontend/src/screens/pairingGameScreen.tsx
@@ -41,51 +41,53 @@ export default function PairingGameScreen() {
     const extraButtonStyles = canClickDoneButton ? {} : styles.inactiveButton
     return (
         <DraxProvider>
-            <View style={styles.column}>
-                {submitted ? <Text style={styles.scoreText}>{correctValues}/{turkishWords?.length ?? 0}</Text> :
-                    englishWords?.map(word => {
-                        if (turkishWords?.some(({ english }) => english === word) ?? false) {
-                            return (<View key={word} style={styles.englishUsed} />)
-                        }
-                        return (<DraxView payload={word} key={word} style={styles.draxView} draggingStyle={styles.englishUsed} dragReleasedStyle={styles.englishUsed}>
-                            <Text style={styles.english}>{word}</Text>
-                        </DraxView>)
-                    })
-                }
-            </View>
-            <View style={styles.turkishContainer}>
-                {turkishWords?.map((word, i) => (
-                    <DroppableRow
-                        key={word.turkish}
-                        showingResults={submitted}
-                        wordDropped={(newWord) => {
-                            const newTurkishWords = [...turkishWords]
-                            newTurkishWords[i] = { english: newWord, turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
-                            setTurkishWords(newTurkishWords)
-                        }}
-                        turkish={word.turkish}
-                        english={word.english}
-                        correctEnglish={word.correctEnglishWord}
-                        removeWord={
-                            () => {
+            <View style={styles.container}>
+                <View style={{...styles.column, flex: submitted ? 5 : 8}}>
+                    {submitted ? <Text style={styles.scoreText}>{correctValues}/{turkishWords?.length ?? 0}</Text> :
+                        englishWords?.map(word => {
+                            if (turkishWords?.some(({ english }) => english === word) ?? false) {
+                                return (<View key={word} style={styles.englishUsed} />)
+                            }
+                            return (<DraxView payload={word} key={word} style={styles.draxView} draggingStyle={styles.englishUsed} dragReleasedStyle={styles.englishUsed}>
+                                <Text style={styles.english}>{word}</Text>
+                            </DraxView>)
+                        })
+                    }
+                </View>
+                <View style={styles.turkishContainer}>
+                    {turkishWords?.map((word, i) => (
+                        <DroppableRow
+                            key={word.turkish}
+                            showingResults={submitted}
+                            wordDropped={(newWord) => {
                                 const newTurkishWords = [...turkishWords]
-                                newTurkishWords[i] = { turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
+                                newTurkishWords[i] = { english: newWord, turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
                                 setTurkishWords(newTurkishWords)
                             }}
-                    />))}
-            </View>
-            <View style={styles.doneContainer}>
-                {submitted && <TouchableOpacity style={styles.doneButton} onPress={() => {
-                    setTurkishWords(turkishWords?.map((word) => ({ ...word, english: undefined })))
-                    setSubmitted(false)
-                }}><Text style={styles.doneButtonTitle}>play again</Text></TouchableOpacity>}
-                <TouchableOpacity style={{ ...styles.doneButton, ...extraButtonStyles }} disabled={!canClickDoneButton} onPress={() => {
-                    if (submitted) {
-                        navigation.navigate("home")
-                    } else {
-                        setSubmitted(true)
-                    }
-                }}><Text style={styles.doneButtonTitle}>{submitted ? "end session" : "done"}</Text></TouchableOpacity>
+                            turkish={word.turkish}
+                            english={word.english}
+                            correctEnglish={word.correctEnglishWord}
+                            removeWord={
+                                () => {
+                                    const newTurkishWords = [...turkishWords]
+                                    newTurkishWords[i] = { turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
+                                    setTurkishWords(newTurkishWords)
+                                }}
+                        />))}
+                </View>
+                <View style={styles.doneContainer}>
+                    {submitted && <TouchableOpacity style={styles.doneButton} onPress={() => {
+                        setTurkishWords(turkishWords?.map((word) => ({ ...word, english: undefined })))
+                        setSubmitted(false)
+                    }}><Text style={styles.doneButtonTitle}>play again</Text></TouchableOpacity>}
+                    <TouchableOpacity style={{ ...styles.doneButton, ...extraButtonStyles }} disabled={!canClickDoneButton} onPress={() => {
+                        if (submitted) {
+                            navigation.navigate("home")
+                        } else {
+                            setSubmitted(true)
+                        }
+                    }}><Text style={styles.doneButtonTitle}>{submitted ? "end session" : "done"}</Text></TouchableOpacity>
+                </View>
             </View>
         </DraxProvider>
     )
@@ -104,7 +106,8 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: "center",
         width: "100%",
-        height: "100%"
+        height: "100%",
+        paddingTop: "5%"
     },
     inactiveButton: {
         backgroundColor: "#D16B5025",
@@ -113,7 +116,6 @@ const styles = StyleSheet.create({
         flex: 8,
         width: "100%",
         alignItems: "center",
-        paddingTop: "10%",
         flexWrap: "wrap",
         flexDirection: "row",
     },
@@ -123,19 +125,19 @@ const styles = StyleSheet.create({
     },
     english: {
         ...defaultStyle.default,
-        paddingVertical: "10%",
-        marginVertical: "4%",
-        backgroundColor: BLUE,
     },
     draxView: {
         width: "40%",
         marginHorizontal: "5%",
         height: "15%",
-        marginVertical: "3%"
+        marginVertical: "3%",
+        backgroundColor: BLUE,
+        justifyContent: 'center'
     },
     doneContainer: {
         flex: 3,
         alignItems: "center",
+        justifyContent: "center"
     },
     doneButton: {
         backgroundColor: "#D16B50",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5456,6 +5456,15 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-native-drax@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/react-native-drax/-/react-native-drax-0.9.1.tgz#ba62422b29adecf02348f25feafc1e939c3d2c23"
+  integrity sha512-yuoupvkr43AfuRiBZAeB7yKw6faFuYTbW1lDRuWe8rxUObPLtzSKQ8w6SEjY2LftRfuKSSctji3yuv1ket8Zuw==
+  dependencies:
+    lodash.isequal "^4.5.0"
+    lodash.throttle "^4.1.1"
+    typesafe-actions "^5.1.0"
+
 react-native-gesture-handler@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"
@@ -6360,6 +6369,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typesafe-actions@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
+  integrity sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==
 
 typescript@~4.0.0:
   version "4.0.8"


### PR DESCRIPTION
Closes #60 . Adds drag and drop game. When the user clicks "done", their score is shown and they can either play again or finish the session.

Some notes:
- Dragging leaves behind a "duplicate" of the word
- Playing again uses the same words as the previous round and does not reshuffle them
- Styling is a bit hacky but it works
- The borders on android are on the outside of selected english words and not the inside

Screenshots:
Initial screen
![image](https://user-images.githubusercontent.com/7697688/143077254-ce0b7816-256f-4ee6-a85f-1b92a9e66965.png)
Dragging
![image](https://user-images.githubusercontent.com/7697688/143077293-c1860593-2413-4f68-94e0-87efb254aa94.png)
Placed words
![image](https://user-images.githubusercontent.com/7697688/143077390-eb0b6e0f-083c-44c8-8715-a405bb72e65a.png)
Finished game
![image](https://user-images.githubusercontent.com/7697688/143077429-6c749754-fdc7-404f-8971-340c6161e152.png)
Here's how the game looks for a `numPairs = 4`
![image](https://user-images.githubusercontent.com/7697688/143077502-f0e1ccee-f4af-4401-9dd8-8be875468957.png)


