### PR TITLE
flow logo is now centered on android

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -13,8 +13,9 @@ const Stack = createNativeStackNavigator();
 export default function App() {
 
   const HOME_HEADER_OPTIONS = {
-    headerTitle: () => {return <Image style={styles.mainImage} source={require('./src/assets/flow-icon.png')}/>},
+    headerTitle: () => { return <Image style={styles.mainImage} source={require('./src/assets/flow-icon.png')} /> },
     title: '',
+    headerTitleAlign: "center" as "center",
     headerShadowVisible: false,
     headerTintColor: '#D16B50',
     headerBackTitle: '',
@@ -23,7 +24,7 @@ export default function App() {
       elevation: 0,
       shadowOpacity: 0,
       borderBottomWidth: 0,
-    },
+    }
   }
 
   const NAV_THEME = {
@@ -41,7 +42,7 @@ export default function App() {
         <Stack.Screen name="SignInFlow" component={signInFlow} options={{ headerShown: false, gestureEnabled: false }} />
         <Stack.Screen name="HomeScreen" component={Homescreen} options={{ gestureEnabled: false, headerBackVisible: false }} />
         <Stack.Screen name="SettingsScreen" component={AccountSettings} />
-        <Stack.Screen name="GameScreen" component={PairingGameScreen}/>
+        <Stack.Screen name="GameScreen" component={PairingGameScreen} />
         <Stack.Screen name="RevisitOnboarding" component={OnboardingScreens} options={{ headerShown: false }} />
       </Stack.Navigator>
     </NavigationContainer>


### PR DESCRIPTION
Closes #81. [This page](https://reactnavigation.org/docs/native-stack-navigator#options) shows that the default centering is left, except on iOS.
![image](https://user-images.githubusercontent.com/7697688/144764554-cff6ca8c-7329-4b6f-a488-a1f61c317971.png)
