### PR TITLE
115 unselected words remain blue

### DIFF
--- a/frontend/src/components/DroppableRow.tsx
+++ b/frontend/src/components/DroppableRow.tsx
@@ -8,12 +8,25 @@ interface DroppableRowProps {
     correctEnglish: string,
     removeWord: () => void;
     wordDropped: (word: string) => void;
-    showingResults: boolean
+    showingResults: boolean,
+    isPairing: boolean
 }
 
-export default function DroppableRow({ turkish, english, removeWord, wordDropped, showingResults, correctEnglish }: DroppableRowProps) {
-    const correct = english === correctEnglish || !english;
-    const extraTurkishInfo = showingResults ? correct ? showingResultsStyles.correctTurkishWord : showingResultsStyles.incorrectTurkishWord : {}
+export default function DroppableRow({ turkish, english, removeWord, wordDropped, showingResults, correctEnglish, isPairing }: DroppableRowProps) {
+    const correct = english === correctEnglish;
+    const unusedSelectingWord = !english && !isPairing;
+
+    let extraTurkishInfo;
+    if (showingResults) {
+        if (correct) {
+            extraTurkishInfo = showingResultsStyles.correctTurkishWord;
+        } else if (unusedSelectingWord) {
+            extraTurkishInfo = showingResultsStyles.unusedTurkishWord;
+        } else {
+            extraTurkishInfo = showingResultsStyles.incorrectTurkishWord
+        }
+    }
+
     const [dragging, setDragging] = useState(false)
     return (<View style={styles.container}>
         <View style={{ ...styles.turkishContainer, ...extraTurkishInfo }}>
@@ -60,6 +73,10 @@ const showingResultsStyles = StyleSheet.create({
         backgroundColor: "#5BBAB7",
         borderColor: "transparent"
     },
+    unusedTurkishWord: {
+        backgroundColor: BLUE,
+        borderColor: "transparent"
+    }
 })
 
 const styles = StyleSheet.create({

--- a/frontend/src/screens/pairingGameScreen.tsx
+++ b/frontend/src/screens/pairingGameScreen.tsx
@@ -120,6 +120,7 @@ export default function PairingGameScreen(props: PairingGameScreenProps) {
                                     newTurkishWords[i] = { turkish: word.turkish, correctEnglishWord: word.correctEnglishWord }
                                     setTurkishWords(newTurkishWords)
                                 }}
+                            isPairing={isPairingGame(user as User)}
                         />))}
                 </View>
                 <View style={styles.doneContainer}>


### PR DESCRIPTION
In the selecting version of the game, when an answer is chosen, that turkish word should be green (if correct) or red (if incorrect), and all unchosen ones should remain blue. 

The behavior of the pairing game should not have changed (i.e. all correct pairings should be green and all incorrect pairings should be red. Nothing should be blue).

Closes #115 

cc: @ShashJar 