### PR TITLE
170 Reshuffling of Game Screen Words After Closing Tutorial

### DIFF
--- a/frontend/src/screens/GameScreen/gameScreen.tsx
+++ b/frontend/src/screens/GameScreen/gameScreen.tsx
@@ -43,7 +43,7 @@ export default function GameScreen(props: SpecificGameScreenProps) {
     const navigation = useNavigation()
     const [isLoading, setIsLoading] = useState(false);
     const gameStateContext = useContext(GameStateContext);
-    const [showingModal, setShowModal] = useState(true);
+    const [showingModal, setShowingModal] = useState(true);
 
     // ref for tutorial modal
     const bottomSheetRef = useRef<BottomSheet>(null);
@@ -54,7 +54,7 @@ export default function GameScreen(props: SpecificGameScreenProps) {
     // handle close press for tutorial modal
     const handleClosePress = useCallback(() => {
         bottomSheetRef.current?.close();
-        setShowModal(false);
+        setShowingModal(false);
     }, []);
 
     useEffect(() => {
@@ -74,7 +74,7 @@ export default function GameScreen(props: SpecificGameScreenProps) {
                 }).catch(console.error);
             }).catch(console.error);
         }
-    }, [gameStateContext.roundId, showingModal]);
+    }, [gameStateContext.roundId]);
 
     useEffect(() => {
         if (submitted) {

--- a/frontend/src/screens/GameTutorial/GameTutorialScreens.tsx
+++ b/frontend/src/screens/GameTutorial/GameTutorialScreens.tsx
@@ -9,10 +9,10 @@ const tutorialImages = {
 	page1: require('../../assets/tutorial-page-1.png'),
 	page2: require('../../assets/tutorial-page-2.png'),
 	page3: require('../../assets/tutorial-page-3.png'),
-    page5Pairing: require('../../assets/pairing-tutorial-page-5.png'),
-    page5Selecting: require('../../assets/selecting-tutorial-page-5.png'),
-    page6: require('../../assets/tutorial-page-6.png'),
-    page7: require('../../assets/tutorial-page-7.png')
+  page5Pairing: require('../../assets/pairing-tutorial-page-5.png'),
+  page5Selecting: require('../../assets/selecting-tutorial-page-5.png'),
+  page6: require('../../assets/tutorial-page-6.png'),
+  page7: require('../../assets/tutorial-page-7.png')
 };
 
 interface GameTutorialScreenProps {


### PR DESCRIPTION
Fixes reshuffling of English and Turkish words on game screen after the user closes the tutorial. Previously, these words would get shuffled and there would be issues with the drag-and-drop (words won't place correctly, words will jump around after being placed). Simple fix: showingModal state variable shouldn't have been in the Game Screen useEffect (we don't want to re-render the game screen when the tutorial modal is closed - we just want to stop showing the modal and keep the underlying components the same).