### PR TITLE
174 clear registration form after account creation

### DIFF
--- a/frontend/src/screens/Login/signUp.tsx
+++ b/frontend/src/screens/Login/signUp.tsx
@@ -38,7 +38,12 @@ export default function SignUpPage({ goToSignIn, goToAccountSettings }: SignUpPa
                     setError("Passwords do not match.")
                 } else {
                     interactor.createAccount(email, password)
-                        .then(goToAccountSettings)
+                        .then(() => {
+                            setEmail("");
+                            setPassword("");
+                            setConfirmPassword("");
+                            goToAccountSettings();
+                        })
                         .catch(e => {
                             console.log(e.message);
                             setError(mapErrorCodeToMessage(e.code))

--- a/frontend/src/screens/Login/signUp.tsx
+++ b/frontend/src/screens/Login/signUp.tsx
@@ -42,7 +42,7 @@ export default function SignUpPage({ goToSignIn, goToAccountSettings }: SignUpPa
                             setEmail("");
                             setPassword("");
                             setConfirmPassword("");
-                            goToAccountSettings();
+                            goToSignIn();
                         })
                         .catch(e => {
                             console.log(e.message);


### PR DESCRIPTION
Closes #174.

Previously, if you logged out after registering an account, you would land on the sign up page with the registration form still filled.

Now it should behave as follows:

1. Register a new account (fill out form and submit)
2. Verify email
3. Land on home screen
4. Press on Profile
5. Press on log out button
6. Land on sign up page with a cleared form